### PR TITLE
 hot reload for rateLimit options

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "main": "src/index.js",
   "typings": "typings/index.d.ts",
   "files": [
-    "src/index.js"
+    "src/index.js",
+    "typings/index.d.ts"
   ],
   "scripts": {
     "watch": "yarn jest --watch",

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,16 @@ AxiosRateLimit.prototype.shift = function () {
   this.timeslotRequests += 1
 }
 
+AxiosRateLimit.prototype.updateRateLimitOptions = function (options) {
+  if ('maxRequests' in options) {
+    this.maxRequests = options.maxRequests
+  }
+
+  if ('perMilliseconds' in options) {
+    this.perMilliseconds = options.perMilliseconds
+  }
+}
+
 /**
  * Apply rate limit to axios instance.
  *
@@ -87,11 +97,14 @@ AxiosRateLimit.prototype.shift = function () {
  * @returns {Object} axios instance with interceptors added
  */
 function axiosRateLimit (axios, options) {
-  new AxiosRateLimit({
+  var instance = new AxiosRateLimit({
     maxRequests: options.maxRequests,
     perMilliseconds: options.perMilliseconds,
     axios: axios
   })
+
+  axios.updateOptions = AxiosRateLimit
+    .prototype.updateRateLimitOptions.bind(instance)
 
   return axios
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,8 @@
 import { AxiosInstance } from 'axios';
 
-export interface RateLimitedAxiosInstance extends AxiosInstance {}
+export interface RateLimitedAxiosInstance extends AxiosInstance {
+    updateRateLimitOptions: (options: { maxRequests?: number, perMilliseconds?: number }) => void;
+}
 
 declare function axiosRateLimit(
     axiosInstance: AxiosInstance,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios';
 
-interface RateLimitedAxiosInstance extends AxiosInstance {}
+export interface RateLimitedAxiosInstance extends AxiosInstance {}
 
 declare function axiosRateLimit(
     axiosInstance: AxiosInstance,


### PR DESCRIPTION
в нашем проекте появилась необходимость менять рейтЛимит по условию.

был конечно вариант останавливать получение новых реквестов у инстанса, создание нового инстанса, а у старого считать количество реквестов и прибивание его когда очередь очистится.
но это очень коряво.

так что решил добавить возможность динамического изменения рейт лимита у конкретного инстанса.
протестировал - частота запросов меняется (добавлял консоль логи в методе shift)
