### PR TITLE
Do not keep process alive waiting for request timeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,10 +59,13 @@ AxiosRateLimit.prototype.shift = function () {
   queued.resolve()
 
   if (this.timeslotRequests === 0) {
-    setTimeout(function () {
+    const timeOut = setTimeout(function () {
       this.timeslotRequests = 0
       this.shift()
-    }.bind(this), this.perMilliseconds).unref()
+    }.bind(this), this.perMilliseconds)
+    // In Node we can avoid keeping process alive unnecessarily by calling
+    // unref() on timeout object. That's not available elsewhere.
+    typeof timeOut.unref === 'function' ? timeOut.unref() : null
   }
   this.timeslotRequests += 1
 }

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ AxiosRateLimit.prototype.shift = function () {
     setTimeout(function () {
       this.timeslotRequests = 0
       this.shift()
-    }.bind(this), this.perMilliseconds)
+    }.bind(this), this.perMilliseconds).unref()
   }
   this.timeslotRequests += 1
 }

--- a/src/index.js
+++ b/src/index.js
@@ -59,13 +59,13 @@ AxiosRateLimit.prototype.shift = function () {
   queued.resolve()
 
   if (this.timeslotRequests === 0) {
-    const timeOut = setTimeout(function () {
+    var timeOut = setTimeout(function () {
       this.timeslotRequests = 0
       this.shift()
     }.bind(this), this.perMilliseconds)
     // In Node we can avoid keeping process alive unnecessarily by calling
     // unref() on timeout object. That's not available elsewhere.
-    typeof timeOut.unref === 'function' ? timeOut.unref() : null
+    if (typeof timeOut.unref === 'function') timeOut.unref()
   }
   this.timeslotRequests += 1
 }


### PR DESCRIPTION
When using rate limiter with node CLI script, it unnecessarily keeps node process alive waiting for request counter timeout. Using `unref()` is an uncompromising way of letting the process exit if all else has been executed except the request counter timeout.

BTW Linter doesn't pass with clean clone from current master (with or without my change). It complains

```
 Error: /home/tero/src/axios-rate-limit/node_modules/@logux/eslint-config/base.js:
	Configuration for rule "import-helpers/order-imports" is invalid:
	Value {"groups":[["absolute","module"],["parent","sibling","index"]],"newlinesBetween":"always"} should NOT have additional properties.
```

I didn't try to fix that.