### PR TITLE
Fix export in typings.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,4 +7,4 @@ declare function axiosRateLimit(
     options: { maxRequests: number, perMilliseconds: number },
 ): RateLimitedAxiosInstance;
 
-export default axiosRateLimit;
+export = axiosRateLimit;


### PR DESCRIPTION
If you consume this module in a typescript project without `esModuleInterop: true` in your tsconfig, importing as suggested in the documentation (`import rateLimit from 'axios-rate-limit'`) will get you the typings, but the code won't actually be imported properly since it's exported commonjs style. Importing with `import rateLimit = require("axios-rate-limit")` will import the code properly, but won't give you any typings.

This is easy to fix, however. You just have to modify the typings to use an export assignment instead to be consistent with the actual code. This will allow both import styles to work and provide proper typings: synthetic-default-es6 style for those with `esModuleInterop` enabled, as well as traditional commonjs style for those without it. It will even warn you if you try to import es6 style without `esModuleInterop` enabled.
![image](https://user-images.githubusercontent.com/2354433/67804991-50691300-fa4d-11e9-8499-8b50254db298.png)
