### PR TITLE
Add optional maxRPS config value

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,7 +4,7 @@ interface RateLimitedAxiosInstance extends AxiosInstance {}
 
 declare function axiosRateLimit(
     axiosInstance: AxiosInstance,
-    options: { maxRequests: number, perMilliseconds: number },
+    options: { maxRequests: number, perMilliseconds: number, maxRPS?: number },
 ): RateLimitedAxiosInstance;
 
 export = axiosRateLimit;


### PR DESCRIPTION
The `maxRPS` config value is defined in the README but not exposed through the TypeScript typings.