### PR TITLE
Fix slow down on error & Expose rateLimitInstance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,10 @@ AxiosRateLimit.prototype.shift = function () {
  */
 function axiosRateLimit (axios, options) {
   var rateLimitInstance = new AxiosRateLimit(axios)
+
   rateLimitInstance.setRateLimitOptions(options)
+
+  axios.rateLimitInstance = rateLimitInstance
 
   axios.getMaxRPS = AxiosRateLimit.prototype.getMaxRPS.bind(rateLimitInstance)
   axios.setMaxRPS = AxiosRateLimit.prototype.setMaxRPS.bind(rateLimitInstance)

--- a/src/index.js
+++ b/src/index.js
@@ -36,16 +36,17 @@ AxiosRateLimit.prototype.setRateLimitOptions = function (options) {
 
 AxiosRateLimit.prototype.enable = function (axios) {
   function handleError (error) {
+    this.shift()
     return Promise.reject(error)
   }
 
   this.interceptors.request = axios.interceptors.request.use(
     this.handleRequest,
-    handleError
+    handleError.bind(this)
   )
   this.interceptors.response = axios.interceptors.response.use(
     this.handleResponse,
-    handleError
+    handleError.bind(this)
   )
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ AxiosRateLimit.prototype.handleResponse = function (response) {
 }
 
 AxiosRateLimit.prototype.unshift = function (requestHandler) {
-  this.queue.push(requestHandler)
+  this.queue.unshift(requestHandler)
   this.shiftInitial()
 }
 


### PR DESCRIPTION
1. Fix #29
2. Possibility to check queue size for logging
3. Possibility to force priority requests

```js
const api = rateLimit(axios.create(), ...);

setInterval(() => {
  console.log(`api has ${api.rateLimitInstance.queue.length} tasks in the queue`);
}, 1000);
```