### PR TITLE
Expose Internal Queue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,10 @@ AxiosRateLimit.prototype.getMaxRPS = function () {
   return this.maxRequests / perSeconds
 }
 
+AxiosRateLimit.prototype.getQueue = function () {
+  return this.queue
+}
+
 AxiosRateLimit.prototype.setMaxRPS = function (rps) {
   this.setRateLimitOptions({
     maxRequests: rps,
@@ -126,6 +130,7 @@ function axiosRateLimit (axios, options) {
   rateLimitInstance.setRateLimitOptions(options)
 
   axios.getMaxRPS = AxiosRateLimit.prototype.getMaxRPS.bind(rateLimitInstance)
+  axios.getQueue = AxiosRateLimit.prototype.getQueue.bind(rateLimitInstance)
   axios.setMaxRPS = AxiosRateLimit.prototype.setMaxRPS.bind(rateLimitInstance)
   axios.setRateLimitOptions = AxiosRateLimit.prototype.setRateLimitOptions
     .bind(rateLimitInstance)


### PR DESCRIPTION
Expose the internal request queue so users can see how many requests are left.