### PR TITLE
feat: add shouldCountRequest option to rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* Add `shouldCountRequest(config, response)` option: when it returns false the limiter refunds one slot (e.g. for cached responses). Enables integration with axios-cache-adapter so cache hits do not consume the rate limit. See [issue #43](https://github.com/aishek/axios-rate-limit/issues/43) and [doc/use-case-axios-cache-adapter.md](doc/use-case-axios-cache-adapter.md).
 
 ## 1.8.1
 * Fix types by @janvennemann, see https://github.com/aishek/axios-rate-limit/pull/95

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See [source code](https://github.com/aishek/axios-rate-limit/blob/master/src/ind
 - [Multiple rate limits](doc/use-case-multiple-rate-limits.md) — API enforces several limits (e.g. per second and per minute); use multiple windows.
 - [Custom queue](doc/use-case-custom-queue.md) — Pass your own queue (e.g. to log when requests are added or removed).
 - [Retrying failed requests](doc/use-case-retry-failed-requests.md) — Use with axios-retry to rate-limit and retry failed requests (see [issue #24](https://github.com/aishek/axios-rate-limit/issues/24)).
+- [Integration with axios-cache-adapter](doc/use-case-axios-cache-adapter.md) — Don't count cached responses toward the limit (see [issue #43](https://github.com/aishek/axios-rate-limit/issues/43)).
 - [Mocking in Jest](doc/jest-mocking.md) — How to mock axios-rate-limit in Jest so tests do not hit the network (see [issue #51](https://github.com/aishek/axios-rate-limit/issues/51)).
 - [Shared limiter](doc/use-case-shared-rate-limiter.md) — Reuse one limiter instance across multiple axios clients that share the same API quota.
 

--- a/__tests__/cache-adapter-integration.js
+++ b/__tests__/cache-adapter-integration.js
@@ -1,0 +1,72 @@
+var helpers = require('./helpers')
+var axios = helpers.requireAxios(process.env.AXIOS_VERSION)
+var axiosRateLimit = require('../src/index')
+
+it(
+  'cached response refunds slot when shouldCountRequest returns false',
+  async function () {
+    function adapter (config) {
+      var isCacheHit = config.url === '/cached'
+      return Promise.resolve({
+        data: config.url,
+        status: 200,
+        config: config,
+        request: { fromCache: isCacheHit }
+      })
+    }
+
+    var http = axiosRateLimit(
+      axios.create({ adapter: adapter }),
+      {
+        maxRequests: 1,
+        perMilliseconds: 1000,
+        shouldCountRequest: function (config, response) {
+          return !response.request.fromCache
+        }
+      }
+    )
+
+    var start = Date.now()
+    var results = await Promise.all([
+      http.get('/cached'),
+      http.get('/network')
+    ])
+    var elapsed = Date.now() - start
+
+    expect(results[0].data).toEqual('/cached')
+    expect(results[1].data).toEqual('/network')
+    expect(elapsed).toBeLessThan(500)
+  })
+
+it(
+  'without shouldCountRequest cached responses still consume rate limit',
+  async function () {
+    function adapter (config) {
+      var isCacheHit = config.url === '/cached'
+      return Promise.resolve({
+        data: config.url,
+        status: 200,
+        config: config,
+        request: { fromCache: isCacheHit }
+      })
+    }
+
+    var http = axiosRateLimit(
+      axios.create({ adapter: adapter }),
+      { maxRequests: 2, perMilliseconds: 500 }
+    )
+
+    var start = Date.now()
+    var results = await Promise.all([
+      http.get('/network1'),
+      http.get('/network2'),
+      http.get('/cached'),
+      http.get('/network3')
+    ])
+    var elapsed = Date.now() - start
+
+    expect(results.map(function (r) { return r.data })).toEqual([
+      '/network1', '/network2', '/cached', '/network3'
+    ])
+    expect(elapsed).toBeGreaterThanOrEqual(500)
+  })

--- a/doc/use-case-axios-cache-adapter.md
+++ b/doc/use-case-axios-cache-adapter.md
@@ -1,0 +1,27 @@
+# Use case: integration with axios-cache-adapter
+
+When using axios-rate-limit with [axios-cache-adapter](https://github.com/RasCarlito/axios-cache-adapter), cached responses would otherwise consume rate-limit slots because the limiter counts when a request is released from the queue, before the adapter runs. A cache hit does not perform a network request but still used one slot.
+
+Use the optional `shouldCountRequest(config, response)` predicate so that cached responses do not count toward the limit. It is called in the response interceptor with the request config and the response. Return `false` to refund one slot (e.g. for cached responses); omit the option or return `true` to count as usual.
+
+**Example:** Rate-limited client with axios-cache-adapter; cache hits do not consume the limit:
+
+```javascript
+import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
+import { setupCache } from 'axios-cache-adapter';
+
+const cache = setupCache({ maxAge: 15 * 60 * 1000 });
+const api = axios.create({ adapter: cache.adapter });
+
+const http = rateLimit(api, {
+  limits: [{ maxRequests: 10, duration: '1s' }],
+  shouldCountRequest: (config, response) => !response.request.fromCache
+});
+
+http.get('https://api.example.com/users');
+```
+
+axios-cache-adapter sets `response.request.fromCache === true` when the response was served from cache. See [axios-cache-adapter](https://github.com/RasCarlito/axios-cache-adapter) for cache configuration.
+
+See [source code](https://github.com/aishek/axios-rate-limit/blob/master/src/index.js#L233-L258) for all available options. This behavior was added for [issue #43](https://github.com/aishek/axios-rate-limit/issues/43).

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,7 @@ AxiosRateLimit.prototype.setMaxRPS = function (rps) {
 
 AxiosRateLimit.prototype.setRateLimitOptions = function (options) {
   if (!options) return
+  this._shouldCountRequest = options.shouldCountRequest
   var newWindows = buildWindows(options)
   clearWindowsTimeouts(this.windows)
   this.windows = newWindows
@@ -211,6 +212,16 @@ AxiosRateLimit.prototype.handleRequest = function (request) {
 
 AxiosRateLimit.prototype.handleResponse = function (response) {
   var self = this
+  if (typeof self._shouldCountRequest === 'function') {
+    try {
+      if (self._shouldCountRequest(response.config, response) === false) {
+        for (var i = 0; i < self.windows.length; i++) {
+          var w = self.windows[i]
+          w.count = Math.max(0, w.count - 1)
+        }
+      }
+    } catch (e) {}
+  }
   return Promise.resolve(self.shift()).then(function () { return response })
 }
 
@@ -310,6 +321,7 @@ AxiosRateLimit.prototype.shift = function () {
  * @param {Object} options.limits optional array of rate limit entries.
  * @param {Number} options.limits[].maxRequests max requests to perform concurrently in given amount of time.
  * @param {String} options.limits[].duration duration of the rate limit window.
+ * @param {Function} options.shouldCountRequest optional predicate (config, response) => boolean; when false the limiter refunds one slot (e.g. for cached responses). Omitted or true means count.
  * @returns {Object} axios instance with interceptors added
  */
 function axiosRateLimit (axios, options) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -31,7 +31,8 @@ type rateLimitOptions = {
     maxRPS?: number,
     duration?: string | number,
     limits?: RateLimitEntry[],
-    queue?: Queue
+    queue?: Queue,
+    shouldCountRequest?: (config: any, response: any) => boolean
 };
 
 interface AxiosRateLimiter extends RateLimiter {


### PR DESCRIPTION
- Introduced `shouldCountRequest(config, response)` option to control whether cached responses count against the rate limit.
- Updated documentation and changelog to reflect this new feature and its integration with axios-cache-adapter.

Implements https://github.com/aishek/axios-rate-limit/issues/43