### PR TITLE
fix(types): preserve passed axios instance

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -56,8 +56,8 @@ export function getLimiter (options: rateLimitOptions): AxiosRateLimiter;
   *   // sets max 2 requests per 1 second, other will be delayed
   *   // note maxRPS is a shorthand for perMilliseconds: 1000, and it takes precedence
   *   // if specified both with maxRequests and perMilliseconds
- *   const http = rateLimit(axios.create(), { maxRequests: 2, perMilliseconds: 1000, maxRPS: 2 })
- *   http.getMaxRPS() // 2
+  *   const http = rateLimit(axios.create(), { maxRequests: 2, perMilliseconds: 1000, maxRPS: 2 })
+  *   http.getMaxRPS() // 2
   *   http.get('https://example.com/api/v1/users.json?page=1') // will perform immediately
   *   http.get('https://example.com/api/v1/users.json?page=2') // will perform immediately
   *   http.get('https://example.com/api/v1/users.json?page=3') // will perform after 1 second from the first one

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,37 +1,31 @@
 import type { AxiosInstance } from 'axios';
 
-export type RateLimitRequestHandler = {
+type RateLimitRequestHandler = {
   resolve: () => boolean
 }
 
-export interface RateLimiter {
+interface RateLimiter {
     getQueue: () => RateLimitRequestHandler[] | Queue,
     getMaxRPS: () => number,
     setMaxRPS: (rps: number) => void,
     setRateLimitOptions: (options?: rateLimitOptions) => void,
-    // enable(axios: any): void,
-    // handleRequest(request:any):any,
-    // handleResponse(response: any): any,
-    // push(requestHandler:any):any,
-    // shiftInitial():any,
-    // shift():any
 }
 
-export type RateLimitedAxiosInstance<T = AxiosInstance> = T & RateLimiter;
+type RateLimitedAxiosInstance<T = AxiosInstance> = T & RateLimiter;
 
-export type RateLimitEntry = {
+type RateLimitEntry = {
     maxRequests: number,
     duration: string | number
 };
 
-export interface Queue<T = RateLimitRequestHandler> {
+interface Queue<T = RateLimitRequestHandler> {
     push(item: T): void | Promise<void>;
     shift(): T | undefined | Promise<T | undefined>;
     length?: number;
     getLength?(): number | Promise<number>;
 }
 
-export type rateLimitOptions = {
+type rateLimitOptions = {
     maxRequests?: number,
     perMilliseconds?: number,
     maxRPS?: number,
@@ -40,11 +34,14 @@ export type rateLimitOptions = {
     queue?: Queue
 };
 
-export interface AxiosRateLimiter extends RateLimiter {
+interface AxiosRateLimiter extends RateLimiter {
     enable<T>(axios: T): RateLimitedAxiosInstance<T>;
 }
 
-export function getLimiter (options: rateLimitOptions): AxiosRateLimiter;
+interface AxiosRateLimiterConstructor {
+    new (queue?: Queue): AxiosRateLimiter;
+    prototype: AxiosRateLimiter;
+}
 
  /**
   * Apply rate limit to axios instance.
@@ -75,5 +72,19 @@ declare function axiosRateLimit<T = AxiosInstance>(
     axiosInstance: T,
     options?: rateLimitOptions & { rateLimiter?: AxiosRateLimiter }
 ): RateLimitedAxiosInstance<T>;
+
+declare namespace axiosRateLimit {
+    export {
+        RateLimitRequestHandler,
+        RateLimiter,
+        RateLimitedAxiosInstance,
+        RateLimitEntry,
+        Queue,
+        rateLimitOptions,
+        AxiosRateLimiterConstructor,
+    };
+    export const AxiosRateLimiter: AxiosRateLimiterConstructor;
+    export function getLimiter(options: rateLimitOptions): AxiosRateLimiter;
+}
 
 export = axiosRateLimit;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance } from 'axios';
+import type { AxiosInstance } from 'axios';
 
 export type RateLimitRequestHandler = {
   resolve: () => boolean
@@ -17,7 +17,7 @@ export interface RateLimiter {
     // shift():any
 }
 
-export interface RateLimitedAxiosInstance extends AxiosInstance, RateLimiter {}
+export type RateLimitedAxiosInstance<T = AxiosInstance> = T & RateLimiter;
 
 export type RateLimitEntry = {
     maxRequests: number,
@@ -40,11 +40,8 @@ export type rateLimitOptions = {
     queue?: Queue
 };
 
-export interface AxiosRateLimiter extends RateLimiter {}
-
-export class AxiosRateLimiter implements RateLimiter {
-    constructor(options: rateLimitOptions);
-    enable(axios: AxiosInstance): RateLimitedAxiosInstance;
+export interface AxiosRateLimiter extends RateLimiter {
+    enable<T>(axios: T): RateLimitedAxiosInstance<T>;
 }
 
 export function getLimiter (options: rateLimitOptions): AxiosRateLimiter;
@@ -59,8 +56,8 @@ export function getLimiter (options: rateLimitOptions): AxiosRateLimiter;
   *   // sets max 2 requests per 1 second, other will be delayed
   *   // note maxRPS is a shorthand for perMilliseconds: 1000, and it takes precedence
   *   // if specified both with maxRequests and perMilliseconds
-  *   const http = rateLimit(axios.create(), { maxRequests: 2, perMilliseconds: 1000, maxRPS: 2 })
- *    http.getMaxRPS() // 2
+ *   const http = rateLimit(axios.create(), { maxRequests: 2, perMilliseconds: 1000, maxRPS: 2 })
+ *   http.getMaxRPS() // 2
   *   http.get('https://example.com/api/v1/users.json?page=1') // will perform immediately
   *   http.get('https://example.com/api/v1/users.json?page=2') // will perform immediately
   *   http.get('https://example.com/api/v1/users.json?page=3') // will perform after 1 second from the first one
@@ -74,9 +71,9 @@ export function getLimiter (options: rateLimitOptions): AxiosRateLimiter;
   * @param {Number} options.perMilliseconds amount of time to limit concurrent requests.
   * @returns {Object} axios instance with interceptors added
   */
-declare function axiosRateLimit(
-    axiosInstance: AxiosInstance,
+declare function axiosRateLimit<T = AxiosInstance>(
+    axiosInstance: T,
     options?: rateLimitOptions & { rateLimiter?: AxiosRateLimiter }
-): RateLimitedAxiosInstance;
+): RateLimitedAxiosInstance<T>;
 
 export = axiosRateLimit;


### PR DESCRIPTION
## Summary
- make the wrapped client type generic so `axios-rate-limit` preserves the exact axios instance shape passed by the consumer
- avoid NodeNext import-vs-require `AxiosInstance` incompatibilities seen with newer axios releases
- keep runtime behavior unchanged and only adjust the declaration file

## Test plan
- [x] Typecheck a NodeNext TypeScript consumer using `axios@1.12.2` and `axios.create()`
- [x] Typecheck a CommonJS TypeScript consumer using `import = require('axios-rate-limit')`
- [x] Run a CommonJS runtime smoke test to confirm the wrapped client still exposes axios methods and limiter helpers

Made with [Cursor](https://cursor.com)