### PR TITLE
docs: add issue #48 runtime RPS use case and regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Single-window constructor shape (`maxRequests` with one of `perMilliseconds`, `d
 - [Custom queue](doc/use-case-custom-queue.md) — Pass your own queue (e.g. to log when requests are added or removed).
 - [Retrying failed requests](doc/use-case-retry-failed-requests.md) — Use with axios-retry to rate-limit and retry failed requests (see [issue #24](https://github.com/aishek/axios-rate-limit/issues/24)).
 - [Integration with axios-cache-adapter](doc/use-case-axios-cache-adapter.md) — Don't count cached responses toward the limit (see [issue #43](https://github.com/aishek/axios-rate-limit/issues/43)).
+- [Change RPS on the fly](doc/use-case-change-rps-on-the-fly.md) — Update `setMaxRPS`/`setRateLimitOptions` at runtime and speed up queued cancellation handling (see [issue #48](https://github.com/aishek/axios-rate-limit/issues/48)).
 - [Mocking in Jest](doc/jest-mocking.md) — How to mock axios-rate-limit in Jest so tests do not hit the network (see [issue #51](https://github.com/aishek/axios-rate-limit/issues/51)).
 - [Shared limiter](doc/use-case-shared-rate-limiter.md) — Reuse one limiter instance across multiple axios clients that share the same API quota.
 

--- a/__tests__/cancellation.js
+++ b/__tests__/cancellation.js
@@ -171,3 +171,42 @@ it('not delay requests if requests are aborted via signal', async function () {
   expect(end - start).toBeLessThan(perMilliseconds * 2)
   expect(end - start).toBeGreaterThanOrEqual(perMilliseconds)
 })
+
+it('setMaxRPS speeds queued cancels (issue 48)', async function () {
+  var totalRequests = 50
+  function adapter (config) { return Promise.resolve(config) }
+
+  var http = axiosRateLimit(
+    axios.create({ adapter: adapter }),
+    { maxRPS: 1 }
+  )
+
+  var onSuccess = sinon.spy()
+  var onFailure = sinon.spy()
+  var cancelSources = []
+  var requests = []
+
+  for (var i = 0; i < totalRequests; i++) {
+    var source = axios.CancelToken.source()
+    cancelSources.push(source)
+    requests.push(
+      http.get('/users', { cancelToken: source.token })
+        .then(onSuccess)
+        .catch(onFailure)
+    )
+  }
+
+  await Promise.resolve()
+  var start = Date.now()
+  http.setMaxRPS(100000)
+  for (var x = 1; x < cancelSources.length; x++) {
+    cancelSources[x].cancel('cancelled for testing')
+  }
+
+  await Promise.all(requests)
+  var end = Date.now()
+
+  expect(onSuccess.callCount).toEqual(1)
+  expect(onFailure.callCount).toEqual(totalRequests - 1)
+  expect(end - start).toBeLessThan(500)
+})

--- a/doc/use-case-change-rps-on-the-fly.md
+++ b/doc/use-case-change-rps-on-the-fly.md
@@ -1,0 +1,27 @@
+# Use case: change RPS on the fly
+
+You can change throughput at runtime with `setMaxRPS` (or `setRateLimitOptions`) without recreating the axios instance.
+
+This is useful when you detect a condition from responses and want queued requests to settle faster (for example before mass cancellation), as discussed in [issue #48](https://github.com/aishek/axios-rate-limit/issues/48).
+
+**Example:** start with conservative rate, then temporarily increase it and cancel queued requests.
+
+```javascript
+import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
+
+const client = rateLimit(axios.create(), { maxRPS: 1 });
+const sourceList = [];
+
+for (let i = 0; i < 100; i++) {
+  const source = axios.CancelToken.source();
+  sourceList.push(source);
+  client.get('https://api.example.com/users', { cancelToken: source.token })
+    .catch(() => {});
+}
+
+client.setMaxRPS(100000);
+sourceList.slice(1).forEach((source) => source.cancel('cancelled'));
+```
+
+`setMaxRPS(rps)` is equivalent to `setRateLimitOptions({ maxRequests: rps, perMilliseconds: 1000 })`.


### PR DESCRIPTION
Document runtime RPS updates for queued cancellation scenarios and add a regression test confirming queued cancels settle quickly after raising max RPS.