### PR TITLE
feat: add header-driven rate-limit auto adaptation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+* Add response-driven rate-limit adaptation via callback pipeline: new `onResponseRateLimit(config, response, error)` hook, `autoRateLimitByHeaders` toggle, and built-in header parser `getHeaderBasedRateLimitOptions(...)`. Header adaptation supports `X-RateLimit-*`, `X-Rate-Limit-*`, and `RateLimit-*` variants for `limit/reset`, processes both success and error responses, skips invalid headers, and avoids overriding explicit user-configured limits. Includes new docs for enabling/disabling this behavior (see [issue #77](https://github.com/aishek/axios-rate-limit/issues/77)).
 ## 1.9.0
 * Add `shouldCountRequest(config, response)` option: when it returns false the limiter refunds one slot (e.g. for cached responses). Enables integration with axios-cache-adapter so cache hits do not consume the rate limit. See [issue #43](https://github.com/aishek/axios-rate-limit/issues/43) and [doc/use-case-axios-cache-adapter.md](doc/use-case-axios-cache-adapter.md).
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Each `limits[]` entry:
 
 - `queue` (optional): custom queue implementation. Must support `push(item)` and `shift()`, and either `length` or `getLength()`. Sync and async queues are supported.
 - `shouldCountRequest` (optional): predicate `(config, response) => boolean`. If it returns `false`, the limiter refunds one occupied slot (useful for cached responses).
+- `autoRateLimitByHeaders` (optional, default `true`): enables automatic single-window adaptation from response headers (`X-RateLimit-*`, `X-Rate-Limit-*`, `RateLimit-*`) when user rate limits are not explicitly configured.
+- `onResponseRateLimit` (optional): callback `(config, response, error) => rateLimitOptions | void` to customize how rate-limit headers are translated into runtime limiter options.
 - `rateLimiter` (optional): lets you pass an existing limiter instance, so multiple axios clients can share one quota.
 
 ### Runtime API
@@ -82,6 +84,8 @@ Single-window constructor shape (`maxRequests` with one of `perMilliseconds`, `d
 - [Retrying failed requests](doc/use-case-retry-failed-requests.md) — Use with axios-retry to rate-limit and retry failed requests (see [issue #24](https://github.com/aishek/axios-rate-limit/issues/24)).
 - [Integration with axios-cache-adapter](doc/use-case-axios-cache-adapter.md) — Don't count cached responses toward the limit (see [issue #43](https://github.com/aishek/axios-rate-limit/issues/43)).
 - [Change RPS on the fly](doc/use-case-change-rps-on-the-fly.md) — Update `setMaxRPS`/`setRateLimitOptions` at runtime and speed up queued cancellation handling (see [issue #48](https://github.com/aishek/axios-rate-limit/issues/48)).
+- [Auto-adapt from rate-limit headers](doc/use-case-x-ratelimit-headers.md) — Use header-driven runtime adaptation via shared callback pipeline, including custom parsing and priority with explicit user limits (see [issue #77](https://github.com/aishek/axios-rate-limit/issues/77)).
+- [Disable header auto-adaptation](doc/use-case-disable-x-ratelimit-auto-sync.md) — Explicitly turn off automatic adaptation and keep only manually controlled limits.
 - [Mocking in Jest](doc/jest-mocking.md) — How to mock axios-rate-limit in Jest so tests do not hit the network (see [issue #51](https://github.com/aishek/axios-rate-limit/issues/51)).
 - [Shared limiter](doc/use-case-shared-rate-limiter.md) — Reuse one limiter instance across multiple axios clients that share the same API quota.
 

--- a/__tests__/header-adaptation.js
+++ b/__tests__/header-adaptation.js
@@ -1,0 +1,201 @@
+var helpers = require('./helpers')
+var axios = helpers.requireAxios(process.env.AXIOS_VERSION)
+var axiosRateLimit = require('../src/index')
+
+it('auto applies x-ratelimit headers on success', async function () {
+  function adapter (config) {
+    if (config.url === '/seed') {
+      return Promise.resolve({
+        status: 200,
+        data: 'seed',
+        config: config,
+        headers: {
+          'x-ratelimit-limit': '1',
+          'x-ratelimit-reset': '0.3'
+        }
+      })
+    }
+    return Promise.resolve({
+      status: 200,
+      data: config.url,
+      config: config,
+      headers: {}
+    })
+  }
+  var http = axiosRateLimit(axios.create({ adapter: adapter }))
+  await http.get('/seed')
+  var start = Date.now()
+  await Promise.all([http.get('/a'), http.get('/b')])
+  var elapsed = Date.now() - start
+  expect(elapsed).toBeGreaterThanOrEqual(250)
+})
+
+it('auto applies x-rate-limit headers', async function () {
+  function adapter (config) {
+    if (config.url === '/seed') {
+      return Promise.resolve({
+        status: 200,
+        data: 'seed',
+        config: config,
+        headers: {
+          'x-rate-limit-limit': '1',
+          'x-rate-limit-reset': '0.25'
+        }
+      })
+    }
+    return Promise.resolve({
+      status: 200,
+      data: config.url,
+      config: config,
+      headers: {}
+    })
+  }
+  var http = axiosRateLimit(axios.create({ adapter: adapter }))
+  await http.get('/seed')
+  var start = Date.now()
+  await Promise.all([http.get('/a'), http.get('/b')])
+  var elapsed = Date.now() - start
+  expect(elapsed).toBeGreaterThanOrEqual(200)
+})
+
+it('auto applies headers from error response', async function () {
+  function adapter (config) {
+    if (config.url === '/limit') {
+      var error = new Error('too many requests')
+      error.config = config
+      error.response = {
+        status: 429,
+        config: config,
+        headers: {
+          'x-ratelimit-limit': '1',
+          'x-ratelimit-reset': '0.2'
+        }
+      }
+      return Promise.reject(error)
+    }
+    return Promise.resolve({
+      status: 200,
+      data: config.url,
+      config: config,
+      headers: {}
+    })
+  }
+  var http = axiosRateLimit(axios.create({ adapter: adapter }))
+  await http.get('/limit').catch(function () {})
+  var start = Date.now()
+  await Promise.all([http.get('/a'), http.get('/b')])
+  var elapsed = Date.now() - start
+  expect(elapsed).toBeGreaterThanOrEqual(150)
+})
+
+it('ignores invalid reset header values', async function () {
+  function adapter (config) {
+    if (config.url === '/seed') {
+      return Promise.resolve({
+        status: 200,
+        data: 'seed',
+        config: config,
+        headers: {
+          'x-ratelimit-limit': '1',
+          'x-ratelimit-reset': 'nope'
+        }
+      })
+    }
+    return Promise.resolve({
+      status: 200,
+      data: config.url,
+      config: config,
+      headers: {}
+    })
+  }
+  var http = axiosRateLimit(axios.create({ adapter: adapter }))
+  await http.get('/seed')
+  var start = Date.now()
+  await Promise.all([http.get('/a'), http.get('/b')])
+  var elapsed = Date.now() - start
+  expect(elapsed).toBeLessThan(120)
+})
+
+it('explicit limits disable built-in auto adaptation', async function () {
+  function adapter (config) {
+    return Promise.resolve({
+      status: 200,
+      data: config.url,
+      config: config,
+      headers: {
+        'x-ratelimit-limit': '1',
+        'x-ratelimit-reset': '1'
+      }
+    })
+  }
+  var http = axiosRateLimit(
+    axios.create({ adapter: adapter }),
+    { maxRequests: 2, perMilliseconds: 120 }
+  )
+  var start = Date.now()
+  await Promise.all([http.get('/a'), http.get('/b'), http.get('/c')])
+  var elapsed = Date.now() - start
+  expect(elapsed).toBeGreaterThanOrEqual(100)
+  expect(elapsed).toBeLessThan(260)
+})
+
+it('supports explicit disable of header auto adaptation', async function () {
+  function adapter (config) {
+    if (config.url === '/seed') {
+      return Promise.resolve({
+        status: 200,
+        data: 'seed',
+        config: config,
+        headers: {
+          'x-ratelimit-limit': '1',
+          'x-ratelimit-reset': '0.4'
+        }
+      })
+    }
+    return Promise.resolve({
+      status: 200,
+      data: config.url,
+      config: config,
+      headers: {}
+    })
+  }
+  var http = axiosRateLimit(
+    axios.create({ adapter: adapter }),
+    { autoRateLimitByHeaders: false }
+  )
+  await http.get('/seed')
+  var start = Date.now()
+  await Promise.all([http.get('/a'), http.get('/b')])
+  var elapsed = Date.now() - start
+  expect(elapsed).toBeLessThan(120)
+})
+
+it('does not reapply identical auto options repeatedly', async function () {
+  var callCount = 0
+  function adapter (config) {
+    callCount += 1
+    return Promise.resolve({
+      status: 200,
+      data: config.url,
+      config: config,
+      headers: {
+        'x-ratelimit-limit': '1',
+        'x-ratelimit-reset': '0.3'
+      }
+    })
+  }
+  var limiter = axiosRateLimit.getLimiter()
+  var originalSetRateLimitOptions = limiter.setRateLimitOptions.bind(limiter)
+  var appliedAutoCount = 0
+  limiter.setRateLimitOptions = function (options, meta) {
+    if (meta && meta.fromAuto === true) {
+      appliedAutoCount += 1
+    }
+    return originalSetRateLimitOptions(options, meta)
+  }
+  var http = limiter.enable(axios.create({ adapter: adapter }))
+  await http.get('/a')
+  await http.get('/b')
+  expect(callCount).toEqual(2)
+  expect(appliedAutoCount).toEqual(1)
+})

--- a/doc/todo.md
+++ b/doc/todo.md
@@ -1,0 +1,8 @@
+# TODO items
+
+[x] improve README.md by describing in details all of the options, do not rely on "people will read the source code" because they don't
+[x] improve AGENTS.md, use https://github.com/rails/rails/pull/55991/changes as an inspiration
+[x] provide in example in doc/use-case-...-something.md for changing RPS on the fly, I believe it is possible, need a clear example how to achieve that, see https://github.com/aishek/axios-rate-limit/issues/48
+[x] add some kind of callback to support X-RateLimit headers, and provide the use case for it's usage, see https://github.com/aishek/axios-rate-limit/issues/77
+[ ] example https://github.com/aishek/axios-rate-limit/issues/26 and find the core concept that allow to have common rps limit in distributed env, I beleive it's some kind of async storage for current state of limits, implement something similar and the use case inside the lib
+[ ] upgrade tooling to `npm ci` will not provide so many warnings

--- a/doc/use-case-disable-x-ratelimit-auto-sync.md
+++ b/doc/use-case-disable-x-ratelimit-auto-sync.md
@@ -1,0 +1,16 @@
+# Use case: disable header auto-adaptation
+
+You can explicitly disable automatic adaptation from response headers and keep limiter changes fully manual.
+
+```javascript
+import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
+
+const client = rateLimit(axios.create(), {
+  autoRateLimitByHeaders: false
+});
+
+client.setRateLimitOptions({ maxRequests: 5, perMilliseconds: 1000 });
+```
+
+Use this when you prefer stable, manually controlled limits even if the server returns `X-RateLimit*` headers.

--- a/doc/use-case-x-ratelimit-headers.md
+++ b/doc/use-case-x-ratelimit-headers.md
@@ -1,0 +1,36 @@
+# Use case: auto-adapt from rate-limit headers
+
+When an API returns rate-limit headers, you can adapt limiter options at runtime through the same callback path used for user customization.
+
+Default behavior:
+
+- Header auto-adaptation is enabled.
+- It reads `X-RateLimit-*`, `X-Rate-Limit-*`, and `RateLimit-*` variants for `Limit` and `Reset`.
+- It applies only when user limits are not explicitly configured.
+
+If you need custom parsing rules, set `onResponseRateLimit`.
+
+```javascript
+import axios from 'axios';
+import rateLimit from 'axios-rate-limit';
+
+const client = rateLimit(axios.create(), {
+  onResponseRateLimit: (config, response, error) => {
+    const source = response || (error && error.response);
+    if (!source || !source.headers) return;
+
+    const options = rateLimit.getHeaderBasedRateLimitOptions(config, source);
+    if (!options) return;
+
+    return options;
+  }
+});
+
+await client.get('/users');
+```
+
+Notes:
+
+- `reset` supports both Unix timestamp and delta seconds.
+- Invalid or incomplete headers are ignored.
+- If explicit limits are set by user config or runtime API, built-in auto-adaptation is not used.

--- a/src/index.js
+++ b/src/index.js
@@ -346,18 +346,19 @@ AxiosRateLimit.prototype.handleRequest = function (request) {
 }
 
 // Handle response rate limit adaptation
-AxiosRateLimit.prototype._handleResponseRateLimit = function (config, response, error) {
-  var self = this
-  var onResponseRateLimit = self._getResolvedOnResponseRateLimit()
-  if (typeof onResponseRateLimit === 'function') {
-    try {
-      var nextOptions = onResponseRateLimit(config, response, error)
-      if (nextOptions && !self._isSameSingleWindow(nextOptions)) {
-        self.setRateLimitOptions(nextOptions, { fromAuto: true })
-      }
-    } catch (e) {}
+AxiosRateLimit.prototype._handleResponseRateLimit =
+  function (config, response, error) {
+    var self = this
+    var onResponseRateLimit = self._getResolvedOnResponseRateLimit()
+    if (typeof onResponseRateLimit === 'function') {
+      try {
+        var nextOptions = onResponseRateLimit(config, response, error)
+        if (nextOptions && !self._isSameSingleWindow(nextOptions)) {
+          self.setRateLimitOptions(nextOptions, { fromAuto: true })
+        }
+      } catch (e) {}
+    }
   }
-}
 
 AxiosRateLimit.prototype.handleResponse = function (response) {
   var self = this

--- a/src/index.js
+++ b/src/index.js
@@ -345,6 +345,20 @@ AxiosRateLimit.prototype.handleRequest = function (request) {
   })
 }
 
+// Handle response rate limit adaptation
+AxiosRateLimit.prototype._handleResponseRateLimit = function (config, response, error) {
+  var self = this
+  var onResponseRateLimit = self._getResolvedOnResponseRateLimit()
+  if (typeof onResponseRateLimit === 'function') {
+    try {
+      var nextOptions = onResponseRateLimit(config, response, error)
+      if (nextOptions && !self._isSameSingleWindow(nextOptions)) {
+        self.setRateLimitOptions(nextOptions, { fromAuto: true })
+      }
+    } catch (e) {}
+  }
+}
+
 AxiosRateLimit.prototype.handleResponse = function (response) {
   var self = this
   if (typeof self._shouldCountRequest === 'function') {
@@ -357,15 +371,7 @@ AxiosRateLimit.prototype.handleResponse = function (response) {
       }
     } catch (e) {}
   }
-  var onResponseRateLimit = self._getResolvedOnResponseRateLimit()
-  if (typeof onResponseRateLimit === 'function') {
-    try {
-      var nextOptions = onResponseRateLimit(response.config, response, null)
-      if (nextOptions && !self._isSameSingleWindow(nextOptions)) {
-        self.setRateLimitOptions(nextOptions, { fromAuto: true })
-      }
-    } catch (e) {}
-  }
+  self._handleResponseRateLimit(response.config, response, null)
   return Promise.resolve(self.shift()).then(function () { return response })
 }
 
@@ -376,15 +382,7 @@ AxiosRateLimit.prototype.handleErrorResponse = function (error) {
   if (response && response.config) {
     config = response.config
   }
-  var onResponseRateLimit = self._getResolvedOnResponseRateLimit()
-  if (typeof onResponseRateLimit === 'function') {
-    try {
-      var nextOptions = onResponseRateLimit(config, response, error)
-      if (nextOptions && !self._isSameSingleWindow(nextOptions)) {
-        self.setRateLimitOptions(nextOptions, { fromAuto: true })
-      }
-    } catch (e) {}
-  }
+  self._handleResponseRateLimit(config, response, error)
   return Promise.resolve(self.shift()).then(function () {
     return Promise.reject(error)
   })

--- a/src/index.js
+++ b/src/index.js
@@ -103,13 +103,96 @@ function isAsyncQueue (queue) {
   return typeof queue.getLength === 'function'
 }
 
+function hasOwn (obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key)
+}
+
+function hasExplicitRateLimitOptions (options) {
+  if (!options) return false
+  return (
+    hasOwn(options, 'limits') ||
+    hasOwn(options, 'maxRequests') ||
+    hasOwn(options, 'perMilliseconds') ||
+    hasOwn(options, 'maxRPS') ||
+    hasOwn(options, 'duration')
+  )
+}
+
+function normalizeHeaders (headers) {
+  var normalized = {}
+  if (!headers) return normalized
+  var keys = Object.keys(headers)
+  for (var i = 0; i < keys.length; i++) {
+    normalized[keys[i].toLowerCase()] = headers[keys[i]]
+  }
+  return normalized
+}
+
+function getHeaderValue (headers, names) {
+  for (var i = 0; i < names.length; i++) {
+    var value = headers[names[i]]
+    if (value != null && value !== '') return value
+  }
+  return null
+}
+
+function parsePositiveNumber (value) {
+  var num = Number(value)
+  if (!isFinite(num) || num <= 0) return null
+  return num
+}
+
+function getResetMs (resetRaw) {
+  var reset = parsePositiveNumber(resetRaw)
+  if (reset == null) return null
+  var nowSeconds = Date.now() / 1000
+  var deltaSeconds = reset >= 1000000000 ? (reset - nowSeconds) : reset
+  if (!isFinite(deltaSeconds)) return null
+  return Math.max(1, Math.ceil(Math.max(0, deltaSeconds) * 1000))
+}
+
+function getHeaderBasedRateLimitOptions (config, response) {
+  if (!response || !response.headers) return null
+  var headers = normalizeHeaders(response.headers)
+  var limitRaw = getHeaderValue(headers, [
+    'x-ratelimit-limit',
+    'x-rate-limit-limit',
+    'ratelimit-limit'
+  ])
+  var resetRaw = getHeaderValue(headers, [
+    'x-ratelimit-reset',
+    'x-rate-limit-reset',
+    'ratelimit-reset'
+  ])
+  var remainingRaw = getHeaderValue(headers, [
+    'x-ratelimit-remaining',
+    'x-rate-limit-remaining',
+    'ratelimit-remaining'
+  ])
+  var limit = parsePositiveNumber(limitRaw)
+  var perMs = getResetMs(resetRaw)
+  if (limit == null || perMs == null) return null
+  if (remainingRaw != null) {
+    var remaining = Number(remainingRaw)
+    if (!isFinite(remaining)) return null
+  }
+  return {
+    maxRequests: limit,
+    perMilliseconds: perMs
+  }
+}
+
 function AxiosRateLimit (queue) {
   this.queue = queue
   this.windows = []
   this._shiftPromise = Promise.resolve()
+  this._headerAutoEnabled = true
+  this._hasExplicitRateLimitOptions = false
+  this._onResponseRateLimit = null
 
   this.handleRequest = this.handleRequest.bind(this)
   this.handleResponse = this.handleResponse.bind(this)
+  this.handleErrorResponse = this.handleErrorResponse.bind(this)
 }
 
 AxiosRateLimit.prototype.getMaxRPS = function () {
@@ -129,9 +212,62 @@ AxiosRateLimit.prototype.setMaxRPS = function (rps) {
   })
 }
 
-AxiosRateLimit.prototype.setRateLimitOptions = function (options) {
+AxiosRateLimit.prototype._getResolvedOnResponseRateLimit = function () {
+  if (typeof this._onResponseRateLimit === 'function') {
+    return this._onResponseRateLimit
+  }
+  if (!this._headerAutoEnabled || this._hasExplicitRateLimitOptions) {
+    return null
+  }
+  return getHeaderBasedRateLimitOptions
+}
+
+AxiosRateLimit.prototype._isSameSingleWindow = function (options) {
+  if (!options || options.limits) return false
+  var hasMax = hasOwn(options, 'maxRequests')
+  var hasPer = (
+    hasOwn(options, 'perMilliseconds') ||
+    hasOwn(options, 'duration') ||
+    hasOwn(options, 'maxRPS')
+  )
+  if (!hasMax || !hasPer) return false
+  if (this.windows.length !== 1) return false
+  var candidate = buildWindows(options)
+  var current = this.windows[0]
+  var maxMatches = candidate[0].max === current.max
+  var perMsMatches = candidate[0].perMs === current.perMs
+  return maxMatches && perMsMatches
+}
+
+AxiosRateLimit.prototype.setRateLimitOptions = function (options, meta) {
   if (!options) return
+  var context = meta || {}
   this._shouldCountRequest = options.shouldCountRequest
+  if (hasOwn(options, 'onResponseRateLimit')) {
+    this._onResponseRateLimit = options.onResponseRateLimit
+  }
+  if (hasOwn(options, 'autoRateLimitByHeaders')) {
+    this._headerAutoEnabled = options.autoRateLimitByHeaders !== false
+  }
+  if (context.fromAuto !== true && hasExplicitRateLimitOptions(options)) {
+    this._hasExplicitRateLimitOptions = true
+  }
+  if (context.fromAuto === true && this._hasExplicitRateLimitOptions) {
+    return
+  }
+  if (context.fromAuto === true && this._isSameSingleWindow(options)) {
+    return
+  }
+  if (!hasExplicitRateLimitOptions(options)) {
+    var hasOnlyBehaviorOptions = (
+      hasOwn(options, 'shouldCountRequest') ||
+      hasOwn(options, 'onResponseRateLimit') ||
+      hasOwn(options, 'autoRateLimitByHeaders')
+    )
+    if (hasOnlyBehaviorOptions) return
+    buildWindows(options)
+    return
+  }
   var newWindows = buildWindows(options)
   clearWindowsTimeouts(this.windows)
   this.windows = newWindows
@@ -142,8 +278,7 @@ AxiosRateLimit.prototype.enable = function (axios) {
   var self = this
 
   function handleError (error) {
-    self.shift().catch(function () {})
-    return Promise.reject(error)
+    return self.handleErrorResponse(error)
   }
 
   axios.interceptors.request.use(
@@ -222,7 +357,37 @@ AxiosRateLimit.prototype.handleResponse = function (response) {
       }
     } catch (e) {}
   }
+  var onResponseRateLimit = self._getResolvedOnResponseRateLimit()
+  if (typeof onResponseRateLimit === 'function') {
+    try {
+      var nextOptions = onResponseRateLimit(response.config, response, null)
+      if (nextOptions && !self._isSameSingleWindow(nextOptions)) {
+        self.setRateLimitOptions(nextOptions, { fromAuto: true })
+      }
+    } catch (e) {}
+  }
   return Promise.resolve(self.shift()).then(function () { return response })
+}
+
+AxiosRateLimit.prototype.handleErrorResponse = function (error) {
+  var self = this
+  var response = error && error.response
+  var config = error && error.config
+  if (response && response.config) {
+    config = response.config
+  }
+  var onResponseRateLimit = self._getResolvedOnResponseRateLimit()
+  if (typeof onResponseRateLimit === 'function') {
+    try {
+      var nextOptions = onResponseRateLimit(config, response, error)
+      if (nextOptions && !self._isSameSingleWindow(nextOptions)) {
+        self.setRateLimitOptions(nextOptions, { fromAuto: true })
+      }
+    } catch (e) {}
+  }
+  return Promise.resolve(self.shift()).then(function () {
+    return Promise.reject(error)
+  })
 }
 
 AxiosRateLimit.prototype.shiftInitial = function () {
@@ -349,6 +514,7 @@ function getLimiter (options) {
 }
 
 axiosRateLimit._clearWindowsTimeouts = clearWindowsTimeouts
+axiosRateLimit.getHeaderBasedRateLimitOptions = getHeaderBasedRateLimitOptions
 module.exports = axiosRateLimit
 module.exports.AxiosRateLimiter = AxiosRateLimit
 module.exports.getLimiter = getLimiter

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,7 +32,9 @@ type rateLimitOptions = {
     duration?: string | number,
     limits?: RateLimitEntry[],
     queue?: Queue,
-    shouldCountRequest?: (config: any, response: any) => boolean
+    shouldCountRequest?: (config: any, response: any) => boolean,
+    onResponseRateLimit?: (config: any, response: any, error?: any) => rateLimitOptions | void,
+    autoRateLimitByHeaders?: boolean
 };
 
 interface AxiosRateLimiter extends RateLimiter {
@@ -86,6 +88,7 @@ declare namespace axiosRateLimit {
     };
     export const AxiosRateLimiter: AxiosRateLimiterConstructor;
     export function getLimiter(options: rateLimitOptions): AxiosRateLimiter;
+    export function getHeaderBasedRateLimitOptions(config: any, response: any): rateLimitOptions | null;
 }
 
 export = axiosRateLimit;


### PR DESCRIPTION
Add a shared response callback pipeline to adapt limits from X-RateLimit style headers while keeping behavior explicit and predictable. Built-in auto adaptation now respects user-defined limits, supports success/error responses, and includes docs plus tests for enable/disable and override semantics.

Inspired by https://github.com/aishek/axios-rate-limit/issues/77